### PR TITLE
Switch Dark/Light automatically based on user browser preference

### DIFF
--- a/sass/_imports.scss
+++ b/sass/_imports.scss
@@ -52,22 +52,24 @@
     --pwt-chart-grid-stroke: #{$background};
 }
 
-@media (prefers-color-scheme: dark){
-    :root {
-        --text: #{$dark_text};
-        --background: #{$dark_background};
-        --background-accent: #{var(--background-accent)};
+@if variable-exists(dark_text) {   
+    @media (prefers-color-scheme: dark){
+        :root {
+            --text: #{$dark_text};
+            --background: #{$dark_background};
+            --background-accent: #{var(--background-accent)};
 
-        --pwt-panel-background: #{$dark_background_accent};
-        --pwt-text-color: #{$dark_text};
-        --pwt-gauge-default: #{$dark_green};
-        --pwt-gauge-back: #{$dark_background};
-        --pwt-gauge-warn: #{$dark_yellow};
-        --pwt-gauge-crit: #{$dark_red};
-        --pwt-chart-primary: #{$dark_accent};
-        --pwt-chart-grid-stroke: #{$dark_background};
-   }
- }
+            --pwt-panel-background: #{$dark_background_accent};
+            --pwt-text-color: #{$dark_text};
+            --pwt-gauge-default: #{$dark_green};
+            --pwt-gauge-back: #{$dark_background};
+            --pwt-gauge-warn: #{$dark_yellow};
+            --pwt-gauge-crit: #{$dark_red};
+            --pwt-chart-primary: #{$dark_accent};
+            --pwt-chart-grid-stroke: #{$dark_background};
+        }
+    }
+}
 
 html {
     overflow: scroll;

--- a/sass/_imports.scss
+++ b/sass/_imports.scss
@@ -48,8 +48,8 @@
     --red: #{$red};
     --redlight: #{$redlight};
 
-    --pwt-panel-background: #{var(--background-accent)};
-    --pwt-text-color: #{var(--text)};
+    --pwt-panel-background: #{$background_accent};
+    --pwt-text-color: #{$text};
     --pwt-gauge-default: #{$green};
     --pwt-gauge-back: #{$background};
     --pwt-gauge-warn: #{$yellow};

--- a/sass/_imports.scss
+++ b/sass/_imports.scss
@@ -41,6 +41,12 @@
     --background: #{$background};
     --background-accent: #{$background_accent};
     --input-background: #{$input_background};
+    --button_text: #{$button_text};
+    --light-gray: #{$lightGray};
+    --green: #{$green};
+    --yellow: #{$yellow};
+    --red: #{$red};
+    --redlight: #{$redlight};
 
     --pwt-panel-background: #{var(--background-accent)};
     --pwt-text-color: #{var(--text)};
@@ -57,7 +63,14 @@
         :root {
             --text: #{$dark_text};
             --background: #{$dark_background};
-            --background-accent: #{var(--background-accent)};
+            --background-accent: #{$dark_background_accent};
+            --input-background: #{$dark_input_background};
+            --button_text: #{$dark_button_text};
+            --light-gray: #{$dark_lightGray};
+            --green: #{$dark_green};
+            --yellow: #{$dark_yellow};
+            --red: #{$dark_red};
+            --redlight: #{$dark_redlight};
 
             --pwt-panel-background: #{$dark_background_accent};
             --pwt-text-color: #{$dark_text};

--- a/sass/_imports.scss
+++ b/sass/_imports.scss
@@ -37,8 +37,13 @@
 @import './sass/special/_charts.sass';
 
 :root {
-    --pwt-panel-background: #{$background_accent};
-    --pwt-text-color: #{$text};
+    --text: #{$text};
+    --background: #{$background};
+    --background-accent: #{$background_accent};
+    --input-background: #{$input_background};
+
+    --pwt-panel-background: #{var(--background-accent)};
+    --pwt-text-color: #{var(--text)};
     --pwt-gauge-default: #{$green};
     --pwt-gauge-back: #{$background};
     --pwt-gauge-warn: #{$yellow};
@@ -46,6 +51,23 @@
     --pwt-chart-primary: #{$accent};
     --pwt-chart-grid-stroke: #{$background};
 }
+
+@media (prefers-color-scheme: dark){
+    :root {
+        --text: #{$dark_text};
+        --background: #{$dark_background};
+        --background-accent: #{var(--background-accent)};
+
+        --pwt-panel-background: #{$dark_background_accent};
+        --pwt-text-color: #{$dark_text};
+        --pwt-gauge-default: #{$dark_green};
+        --pwt-gauge-back: #{$dark_background};
+        --pwt-gauge-warn: #{$dark_yellow};
+        --pwt-gauge-crit: #{$dark_red};
+        --pwt-chart-primary: #{$dark_accent};
+        --pwt-chart-grid-stroke: #{$dark_background};
+   }
+ }
 
 html {
     overflow: scroll;
@@ -59,13 +81,13 @@ html {
 ::-webkit-scrollbar {
     width: 0;
     height: 6px;
-    background: $input_background;
+    background: var(--input-background);
 
     &:hover {
-        background: $background_accent;
+        background: var(--background-accent);
     }
 }
 
 a {
-    color: $text;
+    color: var(--text);
 }

--- a/sass/proxmox/_proxmoxRRDChart.sass
+++ b/sass/proxmox/_proxmoxRRDChart.sass
@@ -1,2 +1,2 @@
 //div[id^="proxmoxRRDChart-"] > div:nth-child(3) > div
-//    background-color: $background_accent
+//    background-color: var(--background-accent)

--- a/sass/proxmox/_pveCeph.sass
+++ b/sass/proxmox/_pveCeph.sass
@@ -1,2 +1,2 @@
 div[id^="pveCephInstallWindow-"][id$="-innerCt"] div div div div
-	background: $background_accent
+	background: var(--background-accent)

--- a/sass/proxmox/_pveDc.sass
+++ b/sass/proxmox/_pveDc.sass
@@ -1,7 +1,7 @@
 div[id^="pveDcHealth-"][id$="-body"], div[id^="pveDcGuests-"][id$="-body"],
 div[id^="pveDcSummary-"][id$="-innerCt"] > div:nth-child(3) > div:nth-child(2), div[id^="pveDcSummary-"][id$="-innerCt"] > div:nth-child(5) > div:nth-child(2) > div > div,
 div[id^="pveDcSummary-"][id$="-innerCt"] > div:nth-child(3) > div:nth-child(2) > div
-    background-color: $background_accent
+    background-color: var(--background-accent)
 
 div[id^="pveDcSummary-"][id$="-innerCt"] > div:nth-child(4) > div:nth-child(3)
-    border: 1px solid $background_accent
+    border: 1px solid var(--background-accent)

--- a/sass/special/_borders.sass
+++ b/sass/special/_borders.sass
@@ -5,7 +5,7 @@ div[id^="PVE-node-Config-"]:not([id$="-body"]) > div:nth-child(1),
 div[id^="PVE-dc-Config-"]:not([id$="-body"]) > div:nth-child(1),
 div[id^="PVE-storage-Browser"]:not([id$="-body"]) > div:nth-child(1),
 div[id^="pvePanelConfig"]:not([id$="-body"]) > div:nth-child(1)
-    border-bottom: 3px solid $background_accent !important
+    border-bottom: 3px solid var(--background-accent) !important
 
 div[id^="PVE-node-Config-"][id$="-body"],
 div[id^="PVE-dc-Config-"][id$="-body"],
@@ -13,4 +13,4 @@ div[id^="PVE-qemu-Config-"][id$="-body"],
 div[id^="PVE-lxc-Config-"][id$="-body"],
 div[id^="PVE-storage-Browser"][id$="-body"],
 div[id^="pvePanelConfig"][id$="-body"]
-    border-left: 3px solid $background_accent !important
+    border-left: 3px solid var(--background-accent) !important

--- a/sass/special/_charts.sass
+++ b/sass/special/_charts.sass
@@ -18,4 +18,4 @@
 //      canvas#ext-element-*.x-surface-canvas
 //div[id^="proxmoxRRDChart"][id*="-ext-chart-axis-numeric-"] div[id^="ext-element-"] canvas[id^="ext-element-"],
 //div[id^="proxmoxRRDChart"][id*="-ext-chart-axis-time-"] div[id^="ext-element-"] canvas[id^="ext-element-"]
-//    filter: opacity(0.1) drop-shadow(0px 0px 0px $text) drop-shadow(0px 0px 0px $text) drop-shadow(0px 0px 0px $text) drop-shadow(0px 0px 0px $text) drop-shadow(0px 0px 0px $text)
+//    filter: opacity(0.1) drop-shadow(0px 0px 0px var(--text)) drop-shadow(0px 0px 0px var(--text)) drop-shadow(0px 0px 0px var(--text)) drop-shadow(0px 0px 0px var(--text)) drop-shadow(0px 0px 0px var(--text))

--- a/sass/special/_icons.sass
+++ b/sass/special/_icons.sass
@@ -4,7 +4,7 @@
 .pve-itype-icon-processor::before, .pmx-itype-icon-processor::before, .pve-itype-icon-cpu::before
 	background-image: url(../images/icon-cpu.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .pve-itype-icon-memory, .pmx-itype-icon-memory
 	//background-image: url('/pve2/images/dd_icon-ram.png')
@@ -13,7 +13,7 @@
 .pve-itype-icon-memory::before, .pmx-itype-icon-memory::before
 	background-image: url(/pve2/images/icon-memory.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .pve-itype-icon-storage
 	//background-image: url('/pve2/images/dd_icon-hdd.png')
@@ -34,7 +34,7 @@
 .pve-itype-icon-cdrom::before
 	background-image: url(/pve2/images/icon-cd-drive.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 //.pve-itype-treelist-item-icon-cdrom
 //	content: ' '
@@ -55,7 +55,7 @@
 .pve-itype-icon-pci::before
 	background-image: url(/pve2/images/icon-pci.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .pve-itype-icon-usb
 	//background-image: url('/pve2/images/dd_icon-usb.png')
@@ -67,7 +67,7 @@
 .pve-itype-icon-serial::before
 	background-image: url(/pve2/images/icon-serial.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .pve-itype-icon-cloud
 	//background-image: url('/pve2/images/dd_icon-cloud.png')
@@ -79,45 +79,45 @@
 .pve-itype-icon-die::before
 	background-image: url(/pve2/images/icon-die.svg)
 	@include iconPosition()
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .fa-exchange:before
-	color: $text
+	color: var(--text)
 
 .fa-usb:before
-	color: $text
+	color: var(--text)
 
 .fa-object-group:before
-	color: $text
+	color: var(--text)
 
 .fa-hdd-o:before
-	color: $text
+	color: var(--text)
 
 .fa-cloud:before
-	color: $text
+	color: var(--text)
 
 .x-treelist-item-icon.fa:before
 	color: inherit
 
 .fa-volume-up:before
-	color: $text
+	color: var(--text)
 
 
 .fa-ceph:before
 	background-image: url(/pve2/images/logo-ceph.png)
-	@include recolor($text)
+	@include recolor(var(--text))
 
 .fa-sign-out:before
 	color: $red
 
 .fa-language:before
-	color: $text
+	color: var(--text)
 
 .fa-building.online
 	color: $accent !important
 
 .fa-window-restore:before
-	color: $text
+	color: var(--text)
 
 .fa-fw.x-grid-icon-custom.fa
 	&.fa-database
@@ -147,16 +147,16 @@
 .lxc:after
 	background: transparent !important
 	color: $accent
-	text-shadow: 0 0 0 $background !important
+	text-shadow: 0 0 0 var(--background)!important
 
 .qemu:after
 	background: transparent !important
 	color: $accent
-	text-shadow: 0 0 0 $background !important
+	text-shadow: 0 0 0 var(--background)!important
 
 .fa-network-wired:before
 	//background-image: url('/pve2/images/dd_icon-fa-network-wired.svg')
-	color: $text
+	color: var(--text)
 
 .fa-sdn:before
 	//background-image: url('/pve2/images/dd_icon-sdn.svg')

--- a/sass/special/_icons.sass
+++ b/sass/special/_icons.sass
@@ -108,13 +108,13 @@
 	@include recolor($text)
 
 .fa-sign-out:before
-	color: $red
+	color: var(--red)
 
 .fa-language:before
 	color: var(--text)
 
 .fa-building.online
-	color: $accent !important
+	color: var(--accent) !important
 
 .fa-window-restore:before
 	color: var(--text)
@@ -123,13 +123,13 @@
 	&.fa-database
 		color: adjust-color($accent, $lightness: -20%)
 		&.available
-			color: $accent
+			color: var(--accent)
 	&.fa-desktop
-		color: $accent
+		color: var(--accent)
 		&.stopped
 			color: adjust-color($accent, $lightness: -20%)
 	&.fa-cube
-		color: $accent
+		color: var(--accent)
 		&.stopped
 			color: adjust-color($accent, $lightness: -20%)
 	&.fa-file-o
@@ -142,17 +142,17 @@
 	&.fa-tags
 		color: adjust-color($accent, $lightness: -20%)
 	&.fa-th
-		color: $accent !important
+		color: var(--accent) !important
 
 .lxc:after
 	background: transparent !important
-	color: $accent
-	text-shadow: 0 0 0 var(--background)!important
+	color: var(--accent)
+	text-shadow: 0 0 0 var(--background) !important
 
 .qemu:after
 	background: transparent !important
-	color: $accent
-	text-shadow: 0 0 0 var(--background)!important
+	color: var(--accent)
+	text-shadow: 0 0 0 var(--background) !important
 
 .fa-network-wired:before
 	//background-image: url('/pve2/images/dd_icon-fa-network-wired.svg')

--- a/sass/special/_icons.sass
+++ b/sass/special/_icons.sass
@@ -4,7 +4,7 @@
 .pve-itype-icon-processor::before, .pmx-itype-icon-processor::before, .pve-itype-icon-cpu::before
 	background-image: url(../images/icon-cpu.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .pve-itype-icon-memory, .pmx-itype-icon-memory
 	//background-image: url('/pve2/images/dd_icon-ram.png')
@@ -13,7 +13,7 @@
 .pve-itype-icon-memory::before, .pmx-itype-icon-memory::before
 	background-image: url(/pve2/images/icon-memory.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .pve-itype-icon-storage
 	//background-image: url('/pve2/images/dd_icon-hdd.png')
@@ -34,7 +34,7 @@
 .pve-itype-icon-cdrom::before
 	background-image: url(/pve2/images/icon-cd-drive.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 //.pve-itype-treelist-item-icon-cdrom
 //	content: ' '
@@ -55,7 +55,7 @@
 .pve-itype-icon-pci::before
 	background-image: url(/pve2/images/icon-pci.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .pve-itype-icon-usb
 	//background-image: url('/pve2/images/dd_icon-usb.png')
@@ -67,7 +67,7 @@
 .pve-itype-icon-serial::before
 	background-image: url(/pve2/images/icon-serial.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .pve-itype-icon-cloud
 	//background-image: url('/pve2/images/dd_icon-cloud.png')
@@ -79,7 +79,7 @@
 .pve-itype-icon-die::before
 	background-image: url(/pve2/images/icon-die.svg)
 	@include iconPosition()
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .fa-exchange:before
 	color: var(--text)
@@ -105,7 +105,7 @@
 
 .fa-ceph:before
 	background-image: url(/pve2/images/logo-ceph.png)
-	@include recolor(var(--text))
+	@include recolor($text)
 
 .fa-sign-out:before
 	color: $red

--- a/sass/special/_proxmox.sass
+++ b/sass/special/_proxmox.sass
@@ -38,10 +38,10 @@ img[id^="proxmoxlogo-"]
 	// to fix
 	//background-color: darken(var(--background-accent), 1)
 
-.pmx-md thead tr
-    background-color: var(--background-accent);
-	// to fix
-	// background-color: darken(var(--background-accent), 2)
+// .pmx-md thead tr
+//     background-color: var(--background-accent);
+// 	// to fix
+// 	// background-color: darken(var(--background-accent), 2)
 
 .pmx-md tbody td, .pmx-md tbody tr:last-of-type td
 	border-bottom: 1px solid var(--background-accent);

--- a/sass/special/_proxmox.sass
+++ b/sass/special/_proxmox.sass
@@ -34,13 +34,13 @@ img[id^="proxmoxlogo-"]
 	border-left: 3px solid $input_background
 
 .pmx-md tbody tr:nth-of-type(even)
-	background-color: darken($background_accent, 1)
+	background-color: darken(var(--background-accent), 1)
 
 .pmx-md thead tr
-	background-color: darken($background_accent, 2)
+	background-color: darken(var(--background-accent), 2)
 
 .pmx-md tbody td, .pmx-md tbody tr:last-of-type td
-	border-bottom: 1px solid lighten($background_accent, 5)
+	border-bottom: 1px solid lighten(var(--background-accent), 5)
 
 .pmx-md tbody tr:hover td
-	background-color: lighten($background_accent, 10)
+	background-color: lighten(var(--background-accent), 10)

--- a/sass/special/_proxmox.sass
+++ b/sass/special/_proxmox.sass
@@ -34,21 +34,21 @@ img[id^="proxmoxlogo-"]
 	border-left: 3px solid $input_background
 
 .pmx-md tbody tr:nth-of-type(even)
-	background-color: var(--background-accent)
+	background-color: var(--background-accent);
 	// to fix
 	//background-color: darken(var(--background-accent), 1)
 
 .pmx-md thead tr
-    background-color: var(--background-accent)
+    background-color: var(--background-accent);
 	// to fix
 	// background-color: darken(var(--background-accent), 2)
 
 .pmx-md tbody td, .pmx-md tbody tr:last-of-type td
-	border-bottom: 1px solid var(--background-accent)
+	border-bottom: 1px solid var(--background-accent);
 	// to fix
 	// border-bottom: 1px solid lighten(var(--background-accent), 5)
 
 .pmx-md tbody tr:hover td
-	background-color: var(--background-accent)
+	background-color: var(--background-accent);
 	// to fix
 	// background-color: lighten(var(--background-accent), 10)

--- a/sass/special/_proxmox.sass
+++ b/sass/special/_proxmox.sass
@@ -34,13 +34,21 @@ img[id^="proxmoxlogo-"]
 	border-left: 3px solid $input_background
 
 .pmx-md tbody tr:nth-of-type(even)
-	background-color: darken(var(--background-accent), 1)
+	background-color: var(--background-accent)
+	// to fix
+	//background-color: darken(var(--background-accent), 1)
 
 .pmx-md thead tr
-	background-color: darken(var(--background-accent), 2)
+    background-color: var(--background-accent)
+	// to fix
+	// background-color: darken(var(--background-accent), 2)
 
 .pmx-md tbody td, .pmx-md tbody tr:last-of-type td
-	border-bottom: 1px solid lighten(var(--background-accent), 5)
+	border-bottom: 1px solid var(--background-accent)
+	// to fix
+	// border-bottom: 1px solid lighten(var(--background-accent), 5)
 
 .pmx-md tbody tr:hover td
-	background-color: lighten(var(--background-accent), 10)
+	background-color: var(--background-accent)
+	// to fix
+	// background-color: lighten(var(--background-accent), 10)

--- a/sass/special/_proxmox.sass
+++ b/sass/special/_proxmox.sass
@@ -5,7 +5,7 @@ img[id^="proxmoxlogo-"]
 	background-color: #401314
 
 .usage
-	background-color: $accent
+	background-color: var(--accent)
 
 .usage-wrapper
 	border: 1px solid $accent
@@ -24,14 +24,14 @@ img[id^="proxmoxlogo-"]
 	//background-image: url('/pve2/images/dd_mini-bottom.png') !important
 
 .pmx-hint
-	color: $yellow
+	color: var(--yellow)
 	background-color: transparent
 
 .pmx-md code
-	background-color: $background
+	background-color: var(--background)
 
 .pmx-md pre code
-	border-left: 3px solid $input_background
+	border-left: 3px solid var(--input-background)
 
 .pmx-md tbody tr:nth-of-type(even)
 	background-color: var(--background-accent);

--- a/sass/special/_specific.sass
+++ b/sass/special/_specific.sass
@@ -1,5 +1,5 @@
 #toolbar-1069-innerCt
-	background: $background
+	background: var(--background)
 
 #button-1030
 	background: var(--background-accent)
@@ -21,7 +21,7 @@
 	background: var(--background-accent)
 
 div[id^="toolbar-"][id$="-innerCt"] div[id^="toolbar-"][id$="-targetEl"] div ul li div
-	background-color: $background
+	background-color: var(--background)
 
 div[id^="pveGuestStatusView-"][id$="-body"]
 	background: var(--background-accent)
@@ -39,57 +39,57 @@ div[id^="pveNotesView-"][id$="-innerCt"]
 	background: var(--background-accent)
 
 [id^="tooltip"]
-	background: $accent
+	background: var(--accent)
 	color: var(--text)
 	border-width: 0
 
 [id^="ext-quicktips-tip-body"]
-	background-color: $accent
+	background-color: var(--accent)
 	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-quicktips-tip-innerCt"]
-	background-color: $accent
+	background-color: var(--accent)
 	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-quicktips-tip-ext-quicktips-tip-outerCt"]
-	background-color: $accent
+	background-color: var(--accent)
 	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-form-error"]
-	background-color: $accent
+	background-color: var(--accent)
 	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="toolbar"]
-	background: $background
+	background: var(--background)
 
 [id^="legend"]
 	background: var(--background-accent)
 	border-color: red
 
 a[id^="menuitem-"][id$="-itemEl"] div[class*="fa-refresh"]:before, span[id^="proxmoxButton-"][id$="-btnEl"] span[class*="fa-undo"]:before
-	color: $yellow
+	color: var(--yellow)
 
 a[id^="menuitem-"][id$="-itemEl"] div[class*="fa-trash-o"]:before
-	color: $red
+	color: var(--red)
 
 // Userinfo button specifics
 #userinfo.x-btn
 	//background-color: transparent !important
 	//border: 1px solid #d23d3f !important
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"]
-	background: $background
+	background: var(--background)
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"] > a[class*="x-menu-item-focus"]
 	background: var(--background-accent)
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"] > div[class*="x-menu-item"] > a[aria-disabled="true"]
@@ -101,4 +101,4 @@ div[id^="form-"][id$="-innerCt"][style="height: 160px; width: 356px;"], div[id^=
 	background: var(--background-accent)
 
 div[id="pkgversions"]
-	background-color: var(--background)!important
+	background-color: var(--background) !important

--- a/sass/special/_specific.sass
+++ b/sass/special/_specific.sass
@@ -2,7 +2,7 @@
 	background: $background
 
 #button-1030
-	background: $background_accent
+	background: var(--background-accent)
 	border: 1px solid #d23d3f
 
 #menuitem-1030-iconEl
@@ -18,55 +18,55 @@
 	color: #c52d2f
 
 [id^="pveNodeStatus"]
-	background: $background_accent
+	background: var(--background-accent)
 
 div[id^="toolbar-"][id$="-innerCt"] div[id^="toolbar-"][id$="-targetEl"] div ul li div
 	background-color: $background
 
 div[id^="pveGuestStatusView-"][id$="-body"]
-	background: $background_accent
+	background: var(--background-accent)
 
 div[id^="pveStorageStatusView-"][id$="-body"]
-	background: $background_accent
+	background: var(--background-accent)
 
 div[id^="pveNotesView-"][id$="-innerCt"]
-	background: $background_accent
+	background: var(--background-accent)
 
 [id^="versioninfo"]
-	background: $background_accent
+	background: var(--background-accent)
 
 [id^="proxmoxGauge"]
-	background: $background_accent
+	background: var(--background-accent)
 
 [id^="tooltip"]
 	background: $accent
-	color: $text
+	color: var(--text)
 	border-width: 0
 
 [id^="ext-quicktips-tip-body"]
 	background-color: $accent
-	color: $text
+	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-quicktips-tip-innerCt"]
 	background-color: $accent
-	color: $text
+	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-quicktips-tip-ext-quicktips-tip-outerCt"]
 	background-color: $accent
-	color: $text
+	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
 
 [id^="ext-form-error"]
 	background-color: $accent
-	color: $text
+	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0
@@ -75,7 +75,7 @@ div[id^="pveNotesView-"][id$="-innerCt"]
 	background: $background
 
 [id^="legend"]
-	background: $background_accent
+	background: var(--background-accent)
 	border-color: red
 
 a[id^="menuitem-"][id$="-itemEl"] div[class*="fa-refresh"]:before, span[id^="proxmoxButton-"][id$="-btnEl"] span[class*="fa-undo"]:before
@@ -91,14 +91,14 @@ a[id^="menuitem-"][id$="-itemEl"] div[class*="fa-trash-o"]:before
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"]
 	background: $background
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"] > a[class*="x-menu-item-focus"]
-	background: $background_accent
+	background: var(--background-accent)
 div[id="menu-1029-targetEl"] > div[class*="x-menu-item"] > div[class*="x-menu-item"] > a[aria-disabled="true"]
 	opacity: 0.5
-	background: $background_accent
+	background: var(--background-accent)
 
 // Panels on "My Settings"
 div[id^="form-"][id$="-innerCt"][style="height: 160px; width: 356px;"], div[id^="fieldset-"][id$="-innerCt"]
-	background: $background_accent
+	background: var(--background-accent)
 
 div[id="pkgversions"]
-	background-color: $background !important
+	background-color: var(--background)!important

--- a/sass/x/_autocontainer.sass
+++ b/sass/x/_autocontainer.sass
@@ -1,2 +1,2 @@
 .x-autocontainer-innerCt
-	background: $background
+	background: var(--background)

--- a/sass/x/_body.sass
+++ b/sass/x/_body.sass
@@ -1,7 +1,7 @@
 .x-body
-	color: $text
+	color: var(--text)
 	font-size: 13px
 	line-height: 17px
 	font-weight: 300
 	font-family: 'helvetica', 'arial', 'verdana', sans-serif
-	background: $text
+	background: var(--text)

--- a/sass/x/_boundlist.sass
+++ b/sass/x/_boundlist.sass
@@ -1,6 +1,6 @@
 .x-boundlist-item
   color: var(--text)
-  background-color: $input_background
+  background-color: var(--input-background)
   border: none
   &:hover
     background-color: var(--background-accent)
@@ -8,4 +8,4 @@
     background-color: var(--background-accent)
 
 .x-boundlist
-  border-color: $input_background
+  border-color: var(--input-background)

--- a/sass/x/_boundlist.sass
+++ b/sass/x/_boundlist.sass
@@ -1,11 +1,11 @@
 .x-boundlist-item
-  color: $text
+  color: var(--text)
   background-color: $input_background
   border: none
   &:hover
-    background-color: $background_accent
+    background-color: var(--background-accent)
   &.x-boundlist-selected
-    background-color: $background_accent
+    background-color: var(--background-accent)
 
 .x-boundlist
   border-color: $input_background

--- a/sass/x/_box.sass
+++ b/sass/x/_box.sass
@@ -1,8 +1,8 @@
 .x-box-scroller
-	background: var(--background)!important
+	background: var(--background) !important
 
 .x-box-scroller-body-vertical
-	background: var(--background)!important
+	background: var(--background) !important
 
 .x-box-inner
 	overflow: hidden

--- a/sass/x/_box.sass
+++ b/sass/x/_box.sass
@@ -1,15 +1,15 @@
 .x-box-scroller
-	background: $background !important
+	background: var(--background)!important
 
 .x-box-scroller-body-vertical
-	background: $background !important
+	background: var(--background)!important
 
 .x-box-inner
 	overflow: hidden
 	position: relative
 	left: 0
 	top: 0
-    background: $background_accent
+    background: var(--background-accent)
 
 .x-box-scroller-right
 	//background-image: url('/pve2/images/dd_default-scroll-left.png') !important

--- a/sass/x/_btn.sass
+++ b/sass/x/_btn.sass
@@ -1,5 +1,5 @@
 .x-btn
-	background: $accent
+	background: var(--accent)
 	border-width: 0
 	&.x-unselectable.x-box-item
 		&.x-toolbar-item.x-btn-default-toolbar-small
@@ -16,14 +16,14 @@
 
 .x-keyboard-mode .x-btn-focus, .x-btn-focus
 	&.x-btn-default-toolbar-small
-		background-color: $accent
+		background-color: var(--accent)
 
 .x-btn-inner
-	color: $button_text
+	color: var(----button-text)
 	&.x-btn-inner-default-small
-		color: $button_text
+		color: var(----button-text)
 	&.x-btn-inner-default-toolbar-small
-		color: $button_text
+		color: var(----button-text)
 
 .x-btn-disabled
 	background-image: none
@@ -35,9 +35,9 @@
 			&.fa-undo, &.fa-terminal, &.fa-send-o, &.fa-fw.fa-ellipsis-v, &.fa-refresh
 				color: var(--text)
 			&.fa-play
-				color: $green
+				color: var(--green)
 			&.fa-power-off
-				color: $redlight
+				color: var(--redlight)
 		&.x-btn-icon-el-default-toolbar-small.fa.fa-question-circle
 			color: var(--text)
 	&.x-btn-icon-el-default-small.fa
@@ -51,4 +51,4 @@
 	//background-image: url('/pve2/images/dd_default-toolbar-small-s-arrow.png')
 
 .fa-gear:before, .fa-cog:before
-	color: $button_text
+	color: var(----button-text)

--- a/sass/x/_btn.sass
+++ b/sass/x/_btn.sass
@@ -33,16 +33,16 @@
 	&.x-btn-icon-el-default-toolbar-small
 		&.fa
 			&.fa-undo, &.fa-terminal, &.fa-send-o, &.fa-fw.fa-ellipsis-v, &.fa-refresh
-				color: $text
+				color: var(--text)
 			&.fa-play
 				color: $green
 			&.fa-power-off
 				color: $redlight
 		&.x-btn-icon-el-default-toolbar-small.fa.fa-question-circle
-			color: $text
+			color: var(--text)
 	&.x-btn-icon-el-default-small.fa
 		&.fa-book.x-btn-icon-el-default-toolbar-small, &.black.fa-gear
-			color: $text
+			color: var(--text)
 
 .x-btn-wrap-default-toolbar-small.x-btn-arrow-right:after
 	//background-image: url('/pve2/images/dd_default-toolbar-small-arrow.png')

--- a/sass/x/_column.sass
+++ b/sass/x/_column.sass
@@ -3,7 +3,7 @@
 	border-width: 0 !important
 
 .x-column-header-default
-	background: $background
+	background: var(--background)
 	border-width: 0 !important
 
 .x-column-header-text-inner

--- a/sass/x/_column.sass
+++ b/sass/x/_column.sass
@@ -1,5 +1,5 @@
 .x-column-header-inner
-	background: $background_accent
+	background: var(--background-accent)
 	border-width: 0 !important
 
 .x-column-header-default
@@ -7,7 +7,7 @@
 	border-width: 0 !important
 
 .x-column-header-text-inner
-	color: $text
+	color: var(--text)
 
 .x-column-header-trigger
-	border-color: $background_accent
+	border-color: var(--background-accent)

--- a/sass/x/_component.sass
+++ b/sass/x/_component.sass
@@ -1,6 +1,6 @@
 .x-component
-	color: $text
+	color: var(--text)
 	&.x-box-item.x-component-default
 		background-color: transparent
 	&.x-fieldset-header-text.x-component-default
-		color: $text
+		color: var(--text)

--- a/sass/x/_datepicker.sass
+++ b/sass/x/_datepicker.sass
@@ -1,28 +1,28 @@
 .x-datepicker-column-header-inner
-    background-color: $background
+    background-color: var(--background)
     color: white
 
 .x-datepicker
  	border: none  
 
 .x-datepicker-date
-    background-color: $background
+    background-color: var(--background)
     color: white
     border: none
 
 .x-datepicker-cell
-	border: 0.5px solid $input_background
+	border: 0.5px solid var(--input-background)
 
 .x-datepicker-header
     background-color: var(--background-accent)  
 
 .x-datepicker-footer
-    background-color: $background
+    background-color: var(--background)
 
 .x-monthpicker, .x-monthpicker-buttons
     color: white
     border: none
-    background-color: $background
+    background-color: var(--background)
 
 .x-monthpicker-item-inner
     color: white
@@ -36,4 +36,4 @@
     border: none !important
     color: white !important
     opacity: 1
-    background-color: $input_background !important
+    background-color: var(--input-background) !important

--- a/sass/x/_datepicker.sass
+++ b/sass/x/_datepicker.sass
@@ -14,7 +14,7 @@
 	border: 0.5px solid $input_background
 
 .x-datepicker-header
-    background-color: $background_accent  
+    background-color: var(--background-accent)  
 
 .x-datepicker-footer
     background-color: $background
@@ -30,7 +30,7 @@
     opacity: 0.9
 
 .x-monthpicker-months
-    border-color: $background_accent
+    border-color: var(--background-accent)
 
 .x-monthpicker-selected, .x-datepicker-selected div.x-datepicker-date
     border: none !important

--- a/sass/x/_form.sass
+++ b/sass/x/_form.sass
@@ -1,6 +1,6 @@
 .x-form-text-default
 	color: var(--text)
-	background-color: $input_background
+	background-color: var(--input-background)
 	font: 300 13px/17px 'helvetica', 'arial', 'verdana', sans-serif
 	min-height: 22px
 	padding: 0 6px 2px
@@ -18,7 +18,7 @@
 	//background-image: url('/pve2/images/dd_clear-trigger.png')
 
 .x-form-display-field
-	color: $input_background
+	color: var(--input-background)
 
 .x-form-text
 	color: var(--text)

--- a/sass/x/_form.sass
+++ b/sass/x/_form.sass
@@ -1,5 +1,5 @@
 .x-form-text-default
-	color: $text
+	color: var(--text)
 	background-color: $input_background
 	font: 300 13px/17px 'helvetica', 'arial', 'verdana', sans-serif
 	min-height: 22px
@@ -21,10 +21,10 @@
 	color: $input_background
 
 .x-form-text
-	color: $text
+	color: var(--text)
 
 .x-form-item-label-inner-default
-	color: $text
+	color: var(--text)
 
 .x-form-item-body.x-form-item-body-default.x-form-display-field-body.x-form-display-field-body-default
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)

--- a/sass/x/_grid.sass
+++ b/sass/x/_grid.sass
@@ -1,10 +1,10 @@
 .x-grid-cell-inner
 	background: transparent
-	color: $text
+	color: var(--text)
 
 .x-grid-cell-rowbody
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-grid-item
 	background: $background
@@ -21,7 +21,7 @@
 	border-width: 0 !important
 
 .proxmox-apt-repos .x-grid-group-title, .x-grid-group-title
-	color: $text
+	color: var(--text)
 
 .x-grid-row-loading
 	//background-image: url('/pve2/images/dd_loading.svg')
@@ -29,8 +29,8 @@
 	background-size: auto
 
 .x-grid-group-hd.x-grid-group-hd-collapsible
-	background: $background_accent
-	color: $text
+	background: var(--background-accent)
+	color: var(--text)
 	border-width: 0
 
 .x-grid-icon-custom:after
@@ -42,8 +42,8 @@
 
 .x-grid-empty
 	background-color: inherit
-	color: $text
+	color: var(--text)
 
 .x-grid-row-summary .x-grid-cell, .x-grid-row-summary .x-grid-rowwrap, .x-grid-row-summary .x-grid-cell-rowbody
-	background-color: $background_accent !important
+	background-color: var(--background-accent) !important
 	border-color: $background

--- a/sass/x/_grid.sass
+++ b/sass/x/_grid.sass
@@ -3,21 +3,21 @@
 	color: var(--text)
 
 .x-grid-cell-rowbody
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-grid-item
-	background: $background
+	background: var(--background)
 	border-width: 0 !important
 	&:hover, &.x-grid-item-selected
-		background-color: $input_background
+		background-color: var(--input-background)
 
 .x-grid-item-alt
-	background: $background
+	background: var(--background)
 	border-width: 0 !important
 
 .x-grid-header-ct
-	background: $background
+	background: var(--background)
 	border-width: 0 !important
 
 .proxmox-apt-repos .x-grid-group-title, .x-grid-group-title
@@ -35,10 +35,10 @@
 
 .x-grid-icon-custom:after
 	//If you use compass, instead of the line below you could use + text-shadow($shadow-1, $shadow-2, $shadow-3, $shadow-4, $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9, $shadow-10)
-	text-shadow: 0 0 0 $background
+	text-shadow: 0 0 0 var(--background)
 
 .x-grid-icon-custom.lock-migrate:after
-	color: $yellow
+	color: var(--yellow)
 
 .x-grid-empty
 	background-color: inherit
@@ -46,4 +46,4 @@
 
 .x-grid-row-summary .x-grid-cell, .x-grid-row-summary .x-grid-rowwrap, .x-grid-row-summary .x-grid-cell-rowbody
 	background-color: var(--background-accent) !important
-	border-color: $background
+	border-color: var(--background)

--- a/sass/x/_legend.sass
+++ b/sass/x/_legend.sass
@@ -1,10 +1,10 @@
 .x-legend-item
-	background: $background
+	background: var(--background)
 	color: var(--text)
 	border-width: 0
 
 .x-legend-container
-	background: $background
+	background: var(--background)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	//If you use compass, instead of the line below you could use + box-shadow($shadow-1, $shadow-2, $shadow-3, $shadow-4, $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9, $shadow-10)

--- a/sass/x/_legend.sass
+++ b/sass/x/_legend.sass
@@ -1,6 +1,6 @@
 .x-legend-item
 	background: $background
-	color: $text
+	color: var(--text)
 	border-width: 0
 
 .x-legend-container

--- a/sass/x/_menu.sass
+++ b/sass/x/_menu.sass
@@ -8,20 +8,20 @@
 
 .x-menu-default
 	background: $accent
-	border: 1px solid $background_accent
+	border: 1px solid var(--background-accent)
 
 .x-menu-item-text
-	color: $text
+	color: var(--text)
 
 .x-menu-header
 	border-radius: 1px
-	background: $background_accent
+	background: var(--background-accent)
 	border-width: 0
 
 .x-menu-item-icon-default.x-menu-item-icon.fa
 	&.fa-fw
 		&.fa-building, &.fa-folder, &.fa-floppy-o, &.fa-file-o, &.fa-clone, &.fa-send-o, &.fa-group, &.fa-user, &.fa-user-o, &.fa-bar-chart, &.fa-address-book-o, &.fa-clock-o, &.fa-shield, &.fa-file-text-o, &.fa-yahoo
-			color: $text
+			color: var(--text)
 		&.fa-play
 			color: $green
 		&.fa-stop, &.fa-power-off
@@ -30,7 +30,7 @@
 			color: $yellow
 
 	&.fa-heartbeat, &.fa-cube, &.fa-terminal, &.fa-desktop, &.fa-trash-o
-		color: $text
+		color: var(--text)
 	&.fa-stop
 		color: $redlight
 
@@ -51,17 +51,17 @@ div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"] > a[class*="x-menu-item-focus"],
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) >  div > div:nth-child(2) > div > div[class*="x-menu-item-focus"] > a, // PVE 7.0
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div > div:nth-child(2) > div > div[class*="x-menu-item-focus"] > a // PVE 7.0
-	background: $background_accent
+	background: var(--background-accent)
 
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"] > a[aria-disabled="true"],
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"] > a[aria-disabled="true"],
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div > div:nth-child(2) > div > div[class*="x-menu-item"] > a[aria-disabled="true"], // PVE 7.0
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div > div:nth-child(2) > div > div[class*="x-menu-item"] > a[aria-disabled="true"], // PVE 7.0
 	opacity: 0.5
-	background: $background_accent
+	background: var(--background-accent)
 
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"]>div:nth-child(2)>div:nth-child(3)>div:nth-child(1)>div[class*="x-menu-item"]
 	background: inherit
 
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"]>div:nth-child(2)>div:nth-child(3)>div:nth-child(1)>div[class*="x-menu-item"]>a[class*="x-menu-item-focus"]
-	background: $background_accent
+	background: var(--background-accent)

--- a/sass/x/_menu.sass
+++ b/sass/x/_menu.sass
@@ -2,12 +2,12 @@
 	background-color: adjust-color($accent, $saturation: -30%)
 
 .x-menu-item
-	background: $accent
+	background: var(--accent)
 	border-style: none
 	border-width: 0
 
 .x-menu-default
-	background: $accent
+	background: var(--accent)
 	border: 1px solid var(--background-accent)
 
 .x-menu-item-text
@@ -23,16 +23,16 @@
 		&.fa-building, &.fa-folder, &.fa-floppy-o, &.fa-file-o, &.fa-clone, &.fa-send-o, &.fa-group, &.fa-user, &.fa-user-o, &.fa-bar-chart, &.fa-address-book-o, &.fa-clock-o, &.fa-shield, &.fa-file-text-o, &.fa-yahoo
 			color: var(--text)
 		&.fa-play
-			color: $green
+			color: var(--green)
 		&.fa-stop, &.fa-power-off
-			color: $redlight
+			color: var(--redlight)
 		&.fa-pause, &.fa-download
-			color: $yellow
+			color: var(--yellow)
 
 	&.fa-heartbeat, &.fa-cube, &.fa-terminal, &.fa-desktop, &.fa-trash-o
 		color: var(--text)
 	&.fa-stop
-		color: $redlight
+		color: var(--redlight)
 
 .x-menu-item-default.x-menu-item-separator
 	height: 0
@@ -45,7 +45,7 @@ div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"],
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div > div:nth-child(2) > div > div[class*="x-menu-item"], // PVE 7.0
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div > div:nth-child(2) > div > div[class*="x-menu-item"] // PVE 7.0
-	background: $background
+	background: var(--background)
 
 div[aria-labelledby^="ext-comp-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"] > a[class*="x-menu-item-focus"],
 div[aria-labelledby^="nodeCmdMenu-"][aria-labelledby$="_header-title-textEl"] > div:nth-child(2) > div:nth-child(2) > div > div[class*="x-menu-item"] > a[class*="x-menu-item-focus"],

--- a/sass/x/_misc.sass
+++ b/sass/x/_misc.sass
@@ -6,16 +6,16 @@
 	border: 1px solid $accent
 
 .x-vertical-scroller
-	background: var(--background)!important
+	background: var(--background) !important
 
 .x-css-shadow
 	display: none
 
 .critical
-	color: $red
+	color: var(--red)
 
 .warning
-	color: $yellow
+	color: var(--yellow)
 
 .proxmox-warning-row
 	background-color: rgba($yellow, 0.35)

--- a/sass/x/_misc.sass
+++ b/sass/x/_misc.sass
@@ -6,7 +6,7 @@
 	border: 1px solid $accent
 
 .x-vertical-scroller
-	background: $background !important
+	background: var(--background)!important
 
 .x-css-shadow
 	display: none
@@ -22,7 +22,7 @@
 
 .install-mask
 	color: white
-	background-color: $background_accent
+	background-color: var(--background-accent)
 
 hr[class*="x-component"]
 	border-width: 1px

--- a/sass/x/_panel.sass
+++ b/sass/x/_panel.sass
@@ -1,14 +1,14 @@
 .x-panel-header
-	background: $background_accent
+	background: var(--background-accent)
 	border: 0
 
 .x-panel-body-default
 	background: $background
-	color: $text
+	color: var(--text)
 	font-size: 13px
 	font-weight: 300
 	font-family: 'helvetica', 'arial', 'verdana', sans-serif
-	border-color: $text
+	border-color: var(--text)
 	border-style: solid
 	border-width: 0
 
@@ -16,4 +16,4 @@
 //div[id^="panel-"][id~="-innerCt"][class^="x-autocontainer-innerCt"]
 //	visibility: hidden
 //div[id^="panel-"][class^="x-panel"]
-//	background: $background_accent
+//	background: var(--background-accent)

--- a/sass/x/_panel.sass
+++ b/sass/x/_panel.sass
@@ -3,7 +3,7 @@
 	border: 0
 
 .x-panel-body-default
-	background: $background
+	background: var(--background)
 	color: var(--text)
 	font-size: 13px
 	font-weight: 300

--- a/sass/x/_progress.sass
+++ b/sass/x/_progress.sass
@@ -1,8 +1,8 @@
 .x-progress
-	background: $background
+	background: var(--background)
 
 .x-progress-default .x-progress-bar-default
-		background-color: $green
+		background-color: var(--green)
 
 .x-progress-text
 	color: var(--text) !important

--- a/sass/x/_progress.sass
+++ b/sass/x/_progress.sass
@@ -5,6 +5,6 @@
 		background-color: $green
 
 .x-progress-text
-	color: $text !important
+	color: var(--text) !important
 	&.x-progress-text-back
-		color: $text !important
+		color: var(--text) !important

--- a/sass/x/_splitter.sass
+++ b/sass/x/_splitter.sass
@@ -1,5 +1,5 @@
 .x-splitter
-	background: $background_accent
+	background: var(--background-accent)
 
 .x-splitter-collapsed .x-layout-split-bottom
 	//background-image: url('/pve2/images/dd_mini-top.png')

--- a/sass/x/_tab.sass
+++ b/sass/x/_tab.sass
@@ -7,19 +7,19 @@
 	color: var(--text)
 
 .x-tab-active
-	background: $accent !important
+	background: var(--accent) !important
 	border-width: 0 !important
 
 .x-tab-over
-	background: $accent !important
+	background: var(--accent) !important
 	border-width: 0 !important
 
 .x-tab-default-focus
-	background: $accent !important
+	background: var(--accent) !important
 	border-width: 0 !important
 
 .x-tab-focus
-	background: $accent !important
+	background: var(--accent) !important
 	border-width: 0 !important
 
 .x-tab-bar-body

--- a/sass/x/_tab.sass
+++ b/sass/x/_tab.sass
@@ -1,10 +1,10 @@
 .x-tab
 	background: adjust-color($accent, $saturation: -40%)
-	color: $text
+	color: var(--text)
 	border-width: 0
 
 .x-tab-inner
-	color: $text
+	color: var(--text)
 
 .x-tab-active
 	background: $accent !important
@@ -23,7 +23,7 @@
 	border-width: 0 !important
 
 .x-tab-bar-body
-	background: $background_accent
+	background: var(--background-accent)
 
 .x-tab-disabled
 	background: adjust-color($accent, $saturation: -40%) !important

--- a/sass/x/_tip.sass
+++ b/sass/x/_tip.sass
@@ -1,5 +1,5 @@
 .x-tip-default
-	background-color: $accent
+	background-color: var(--accent)
 	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0

--- a/sass/x/_tip.sass
+++ b/sass/x/_tip.sass
@@ -1,6 +1,6 @@
 .x-tip-default
 	background-color: $accent
-	color: $text
+	color: var(--text)
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
 	border-width: 0

--- a/sass/x/_title.sass
+++ b/sass/x/_title.sass
@@ -1,2 +1,2 @@
 .x-title-text
-	color: $accent
+	color: var(--accent)

--- a/sass/x/_toolbar.sass
+++ b/sass/x/_toolbar.sass
@@ -1,15 +1,15 @@
 .x-toolbar-default
-	background-color: $background
+	background-color: var(--background)
 	border-width: 0
 
 .x-toolbar
-	background: $background
+	background: var(--background)
 
 .x-toolbar-vertical-scroller
-	background: var(--background)!important
+	background: var(--background) !important
 
 .x-toolbar-default-vertical-scroller
-	background: var(--background)!important
+	background: var(--background) !important
 
 .x-toolbar-text.x-box-item.x-toolbar-item.x-toolbar-text-default
 	color: var(--text)

--- a/sass/x/_toolbar.sass
+++ b/sass/x/_toolbar.sass
@@ -6,10 +6,10 @@
 	background: $background
 
 .x-toolbar-vertical-scroller
-	background: $background !important
+	background: var(--background)!important
 
 .x-toolbar-default-vertical-scroller
-	background: $background !important
+	background: var(--background)!important
 
 .x-toolbar-text.x-box-item.x-toolbar-item.x-toolbar-text-default
-	color: $text
+	color: var(--text)

--- a/sass/x/_tree.sass
+++ b/sass/x/_tree.sass
@@ -1,55 +1,55 @@
 .x-tree-icon.x-tree-icon-custom
 	&.x-tree-icon-parent-expanded.fa
 		&.fa-server
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-building
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-database
-			color: $accent !important
+			color: var(--accent) !important
 		
 		&.fa-th
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-desktop
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-cube
-			color: $accent !important
+			color: var(--accent) !important
 	&.x-tree-icon-parent.fa
 		&.fa-server
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-building
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-cube
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-desktop
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-database
-			color: $accent !important
+			color: var(--accent) !important
 
 		&.fa-th
-			color: $accent !important
+			color: var(--accent) !important
 	&.x-tree-icon-leaf.fa
 		&.fa-cube
 			color: adjust-color($accent, $lightness: -20%) !important
 			&.running
-				color: $accent !important
+				color: var(--accent) !important
 		&.fa-fw.fa-unlock
 			color: white
 		&.fa-desktop
-			color: $accent !important
+			color: var(--accent) !important
 			&.stopped
 				color: adjust-color($accent, $lightness: -20%) !important
 		&.fa-database
-			color: $accent !important
+			color: var(--accent) !important
 		&.fa-th
-			color: $accent !important
+			color: var(--accent) !important
 		&.fa-file-o
 			&:before
 				color: rgba($accent, 0.6)
@@ -59,17 +59,17 @@
 				text-shadow: none
 		&.fa-building.online
 			&:before
-				color: $accent
+				color: var(--accent)
 		&.fa-tags
 			color: adjust-color($accent, $lightness: -20%) !important
 	&.lock-migrate:after
-		color: $yellow
+		color: var(--yellow)
 
 .x-tree-icon-parent-expanded:not(.x-tree-icon-custom):before, .x-tree-icon-parent:not(.x-tree-icon-custom):before
 	color: white
 
 .x-tree-icon-custom:after
-	text-shadow: 0 0 0 $background
+	text-shadow: 0 0 0 var(--background)
 
 .x-tree-arrows .x-tree-expander
 	//background-image: url('/pve2/images/dd_arrows.png')

--- a/sass/x/_treelist.sass
+++ b/sass/x/_treelist.sass
@@ -1,34 +1,34 @@
 .x-treelist-item-leaf
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-container
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-row
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-row-with-icon
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-item-expandable
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-item-wrap
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-item-text
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-item-icon
 	background: $background
-	color: $text
+	color: var(--text)
 
 .x-treelist-row-over
 	color: #ff0
@@ -54,7 +54,7 @@
 			transition: background-image .5s
 
 .x-treelist-item-selected > .x-treelist-row
-	background-color: $background_accent
+	background-color: var(--background-accent)
 
 .x-treelist-item-selected > div > div
 	> .pve-itype-treelist-item-icon-cdrom

--- a/sass/x/_treelist.sass
+++ b/sass/x/_treelist.sass
@@ -1,44 +1,44 @@
 .x-treelist-item-leaf
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-container
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-row
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-row-with-icon
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-item-expandable
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-item-wrap
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-item-text
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-item-icon
-	background: $background
+	background: var(--background)
 	color: var(--text)
 
 .x-treelist-row-over
 	color: #ff0
 	> * >
 		.x-treelist-item-text
-			color: $accent
+			color: var(--accent)
 			transition: color .5s
 
 		.x-treelist-item-icon
-			color: $accent
+			color: var(--accent)
 			transition: color .5s
 			&.pve-itype-treelist-item-icon-cdrom
 				//content: ' '
@@ -70,4 +70,4 @@
 		transition: background-image .5s
 
 .x-treelist-item-selected > div > div > div
-	color: $accent
+	color: var(--accent)

--- a/sass/x/_viewport.sass
+++ b/sass/x/_viewport.sass
@@ -1,4 +1,4 @@
 .x-viewport
-	background: $background_accent
+	background: var(--background-accent)
 	> .x-body
-		background: $background_accent
+		background: var(--background-accent)

--- a/sass/x/_window.sass
+++ b/sass/x/_window.sass
@@ -1,21 +1,21 @@
 .x-window-body
-	background: $background_accent
+	background: var(--background-accent)
 	border-bottom-width: 0
 	border-right-width: 0
 
 .x-window-default
 	//If you use compass, instead of the line below you could use + border-radius($radius, $vertical-radius)
 	border-radius: 0
-	background-color: $background_accent
+	background-color: var(--background-accent)
 	//If you use compass, instead of the line below you could use + box-shadow($shadow-1, $shadow-2, $shadow-3, $shadow-4, $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9, $shadow-10)
 	box-shadow: none
-	border-color: $background_accent
+	border-color: var(--background-accent)
 	border-style: none
 	border-width: 0
 	padding: 0
 
 .x-window-default-mc
-	background-color: $background_accent
+	background-color: var(--background-accent)
 
 .x-window-body-default
 	color: white
@@ -30,15 +30,15 @@
 	border-bottom-right-radius: 0 !important
 	//If you use compass, instead of the line below you could use + border-bottom-left-radius($radius)
 	border-bottom-left-radius: 0 !important
-	background-color: $background_accent
+	background-color: var(--background-accent)
 	border-width: 0 !important
 	padding: 9px
 
 .x-window-text
-	color: $text
+	color: var(--text)
 
 .x-window-header.x-header.x-header-draggable.x-docked.x-unselectable.x-window-header-default.x-horizontal.x-window-header-horizontal.x-window-header-default-horizontal.x-top.x-window-header-top.x-window-header-default-top.x-box-layout-ct
-	background: $background_accent
+	background: var(--background-accent)
 	border-bottom-width: 0
 	border-right-width: 0
 

--- a/sass/x/_window.sass
+++ b/sass/x/_window.sass
@@ -43,4 +43,4 @@
 	border-right-width: 0
 
 .x-message-box .x-window-body
-	background-color: $background
+	background-color: var(--background)

--- a/themes/theme-discord-switcher.sass
+++ b/themes/theme-discord-switcher.sass
@@ -1,0 +1,38 @@
+/*!Discord Light & Dark*/
+
+/*Discord Light Colors*/
+$accent: #526DD1;
+
+$green: #57F287;
+$yellow: #FFFF00;
+$red: #ED4245;
+$redlight: #d23d3f;
+
+$background: #ffffff;
+$background_accent: #F2F3F5;
+
+$text: black;
+$button_text: white;
+
+$lightGray: #666;
+$input_background: #E1E2E4;
+
+/*Discord Dark Colors*/
+
+$dark_accent: #526DD1;
+
+$dark_green: #57F287;
+$dark_yellow: #FFFF00;
+$dark_red: #ED4245;
+$dark_redlight: #d23d3f;
+
+$dark_background: #2C2F33;
+$dark_background_accent: #23272a;
+
+$dark_text: white;
+$dark_button_text: white;
+
+$dark_lightGray: #666;
+$dark_input_background: #4A4D53;
+
+@import './sass/_imports.scss';


### PR DESCRIPTION
Uses the `prefers-color-scheme`  CSS media query to automatically switch back and forth between dark + light with the same theme [following this approach](https://melissahie.com/blog/light-dark-mode-sass-css). I combined the Discord Light & Dark to demo.

It mostly works, and should be backwards compatible with the rest of the themes.

Unfortunately, it does not work with the SASS mixins like `adjust-color` or the custom `recolor` since those need colors at compile time, not compatible with the CSS vars. For now I've just kept those as the base variable. 

I didn't see a clear way to fix those, and unfortunately there are quite a few. The most straightforward would be to define additional variables, but that's not great. Will look again when I have time. Or maybe there is another way to do it with SASS I didn't see.

Same theme; switched between Dark/Light preference:

![image](https://github.com/user-attachments/assets/67b69e34-8360-4a88-bd46-6da2138da4bb)

![image](https://github.com/user-attachments/assets/724e7625-1629-4e82-baee-6845f5f812b7)

