### PR TITLE
ZFS ARC bar not showing up when using ZFS

### DIFF
--- a/PVEThemes.py
+++ b/PVEThemes.py
@@ -263,7 +263,7 @@ def addZFSBar():
     f = open(API2_Nodes, "r+", encoding="utf8")
     fileContents = f.read()
 
-    resSTR = "my $res = {\n\t    uptime => 0,\n\t    idle => 0,\n\t};"
+    resSTR = "$res->{uptime} = $uptime;"
 
     #find the line after resSTR
     #resLine = fileContents.find(resSTR) + len(resSTR)


### PR DESCRIPTION
Before the change, the ZFS ARC erroneously says there is no ZFS ARC available because the script does not patch the Nodes.pm file anymore. 

This change restores that functionality by just putting the necessary lines further down in the file and should make it so that the Nodes.pm file is patched once again.

Tested this change on Proxmox 8.4.17 and 9.1.6 and it works on both systems.